### PR TITLE
Stylistic rules overwrites

### DIFF
--- a/index.json
+++ b/index.json
@@ -19,7 +19,9 @@
     ],
     "extends": "airbnb",
     "rules": {
-        "indent": ["error", 4],
+        "indent": ["error", 4, {
+            "SwitchCase": 1
+        }],
         "react/jsx-indent": ["error", 4],
         "react/jsx-indent-props": ["error", 4],
         "prefer-destructuring": "off",


### PR DESCRIPTION
Pozbierajmy w tym PR’ze stylistyczne reguły, które chcemy nadpisać względem airbnb. Stylistyczne, więc będzie można je naprawić `--fix`’em, ale lepiej wprowadzić je wszystkie na raz. Mam nadzieję, że dużo tu tego nie będzie, bo im bliżej się będziemy trzymać airbnb, tym łatwiej utrzymywać i ucinać dyskusje o stylu argumentem „tak jest, bo tak jest w airbnb”†.

___
† Chociaż nie dawanie otwierającej blok klamry w osobnej linii jest obiektywnie złym wyborem. :wink: 