### PR TITLE
Stop masking airbnb’s no-restricted-syntax

### DIFF
--- a/index.json
+++ b/index.json
@@ -38,25 +38,6 @@
                 "some": [ "nesting", "id" ]
             }
         }],
-        "no-restricted-syntax": [
-          "error",
-          {
-            "selector": "ForInStatement",
-            "message": "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array."
-          },
-          {
-            "selector": "ForOfStatement // DISABLED",
-            "message": "iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations."
-          },
-          {
-            "selector": "LabeledStatement",
-            "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand."
-          },
-          {
-            "selector": "WithStatement",
-            "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize."
-          }
-        ],
         "jest/no-disabled-tests": "warn",
         "jest/no-focused-tests": "error",
         "jest/no-identical-title": "error",


### PR DESCRIPTION
We allowed for…of, because it is a nice syntax, but it hurts browser
compatibility. Some phone verndors ship with own “Internet” application
that is based on ancient versions of chrome, so it is an issue.

---

e.g. some browser from a Huawei phone we encountered uses chrome 39 engine. everred.